### PR TITLE
UserPointService 기능 및 동시성 제어 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,119 @@
+# 요구사항 분석
+## 주어진 요구 사항
+
+- PATCH  `/point/{id}/charge` : 포인트를 충전한다.
+- PATCH `/point/{id}/use` : 포인트를 사용한다.
+- *GET `/point/{id}` : 포인트를 조회한다.*
+- *GET `/point/{id}/histories` : 포인트 내역을 조회한다.*
+- *잔고가 부족할 경우, 포인트 사용은 실패하여야 합니다.*
+- *동시에 여러 건의 포인트 충전, 이용 요청이 들어올 경우 순차적으로 처리되어야 합니다.*
+
+<br>
+
+## 요구 사항 분석 및 구체화
+
+### 기능
+
+1. **포인트 충전**
+    - 유효한 회원에게 입력 받은 금액을 회원의 포인트 잔고에 추가한다.
+    - 입력 받은 금액의 범위는 0원 이상 10,000,000원 이하로 설정된다.
+2. **포인트 사용**
+    - 유효한 회원이 가진 포인트 잔고에서 입력 받은 금액만큼 차감한다.
+    - 입력 받은 금액의 범위는 0원 이상 10,000,000원 이하로 설정된다.
+3. **포인트 조회**
+    - 유효한 회원의 포인트 잔고를 조회하여 보여준다.
+    - 만약 유효한 회원이 포인트 잔고를 보유하지 않으면, '0' 을 표시한다.
+4. **포인트 내역 조회**
+    - 유효한 회원의 포인트 내역 테이블에서 내역을 조회한다.
+
+### 기타
+
+1. **포인트 충전/사용 처리 순서**
+    - 여러 건의 포인트 충전 또는 사용 요청은 순차적으로 처리되어야 한다.
+    - 충전 및 사용은 하나의 유저 내에서 순차적으로 이루어진다.
+  
+
+<br>
+<hr>
+<br>
+
+# 동시성 제어 기능을 추가하면서…
+## 1. 동시성 제어란?
+
+  동시성 제어란 여러 명의 사용자(쓰레드)가 하나의 자원을 접근해야 하는 환경에서 데이터의 일관성을 유지하고, 충돌을 방지하기 위해 필요한 매커니즘 입니다.  
+
+  예를 들어, 두 개의 쓰레드가 동일한 계정에 접근하여 포인트 사용 기능을 호출할 때, 동시성 제어가 되어 있지 않으면 각각 호출 시점에 가져온 포인트 잔액에서 사용 처리 하게 되어 최종 결과로는 음수가 발생할 수 있습니다. 만약, 동시성 제어가 되어 있다면 포인트 잔액이라는 하나의 자원에 대해 한 번의 접근만 허용하기 때문에 이러한 문제를 해결할 수 있습니다.
+
+<br>
+
+## 2. 동시성 제어를 하기 위해 생각한 방법
+
+  이번 프로젝트에서는 사용자의 포인트 충전과 사용에 동시성 제어 기능을 추가하기로 하였습니다.
+
+### 2.1 synchronized
+
+### **synchronized란**
+
+  Java에서 동기화를 지원하는 키워드로, 간단하게 특정 코드 블록이나 메서드에 대해 하나의 쓰레드만 접근하도록 제어하는 기능입니다.
+
+### **synchronized를 사용하면 안 되는 이유**
+
+  synchronized를 사용하게 되면 회원의 아이디 별로 동시성 제어가 생기는 것이 아니라 기능(메서드) 자체에 동시성 제어가 생기게 됩니다. 만약, A라는 유저가 포인트 사용을 할 때, B라는 유저가 동시에 포인트 사용을 하지 못하게 되는 현상이 발생되며, 이런 경우 회원들의 불만을 초래할 수 있습니다. 해당 프로젝트에서는 회원의 ID별로 락을 거는 방법이 필요해서 synchronized는 적합하지 않았습니다.
+
+### 2.2 ReentrantLock
+
+### **ReentrantLock이란**
+
+  ReentrantLock은 synchronized와 유사하게 동기화를 제공하지만, 더 세밀하고 유연한 제어가 가능합니다. 이름 그대로 "재진입 가능한" 특성을 가지며, 특정 조건에서 Lock을 해제한 후 다시 획득하여 이후 작업을 이어나갈 수 있도록 지원합니다.
+
+<br>
+
+## 3. 실제 소스에 적용
+
+### 3.1 예제 코드
+
+```java
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class UserPointLockManager {
+    private static final Map<Long, Lock> userPointLocks = new ConcurrentHashMap<>();
+
+    private static Lock getLock(long userId) {
+        return userPointLocks.computeIfAbsent(userId, k -> new ReentrantLock(true));
+    }
+
+    public static void lock(long userId) {
+        Lock lock = getLock(userId);
+        lock.lock();
+    }
+
+    public static void unlock(long userId) {
+        Lock lock = getLock(userId);
+        
+        if(ObjectUtils.isEmpty(lock)) {
+            throw new RuntimeException("존재하지 않는 Lock 객체 입니다.");
+        }
+
+        lock.unlock();
+    }
+}
+```
+
+### 3.2 ID에 대한 Lock 필요성
+
+  앞에서 언급한 대로 포인트 사용/충전 시 A 유저의 행동에 B 유저에게 영향이 가면 안되므로, ID별로 개별적인 락 구현이 필요했습니다. 이를 해결하기 위해 `ConcurrentHashMap` 을 도입하였고, 각 ID 별로 개별적인 락을 관리하도록 구현하였습니다.
+
+### 3.3 LockManager 클래스 추가
+
+  처음엔 Lock에 대한 내용을 Service 코드에 직접 넣었습니다. Lock 관리에 대한 책임을 별도의 클래스에 분산시키면 더 좋을 것 같다고 판단되어 LockManager 클래스를 추가하였습니다. LockManager에게 책임을 분산시키면서 서비스 코드에는 기능 구현에 더 중점을 두었습니다.
+
+<br>
+
+## 4. 결론
+
+  동시성 제어 방식으로 synchronized와 ReentrantLock을 비교한 결과, 세밀한 동작 제어가 가능한 ReentrantLock을 사용하는 것이 적합하다는 결론에 도달했습니다. ConcurrentHashMap을 함께 활용하여 ID별 동시성 제어를 구현하였으며, LockManager 클래스를 추가하여 락 관리의 책임을 분리함으로써 코드의 가독성과 유지보수성을 크게 향상시킬 수 있었습니다.
+    - 여러 건의 포인트 충전 또는 사용 요청은 순차적으로 처리되어야 한다.
+    - 충전 및 사용은 하나의 유저 내에서 순차적으로 이루어진다.

--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -1,5 +1,6 @@
 package io.hhplus.tdd;
 
+import org.apache.coyote.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,5 +11,10 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(value = Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));
+    }
+
+    @ExceptionHandler(value = BadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleException2(Exception e) {
+        return ResponseEntity.status(400).body(new ErrorResponse("400", e.getMessage()));
     }
 }

--- a/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
+++ b/src/main/java/io/hhplus/tdd/ApiControllerAdvice.java
@@ -1,6 +1,5 @@
 package io.hhplus.tdd;
 
-import org.apache.coyote.BadRequestException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,8 +12,8 @@ class ApiControllerAdvice extends ResponseEntityExceptionHandler {
         return ResponseEntity.status(500).body(new ErrorResponse("500", "에러가 발생했습니다."));
     }
 
-    @ExceptionHandler(value = BadRequestException.class)
-    public ResponseEntity<ErrorResponse> handleException2(Exception e) {
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.status(400).body(new ErrorResponse("400", e.getMessage()));
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -3,7 +3,6 @@ package io.hhplus.tdd.point;
 import io.hhplus.tdd.point.dto.UserPointRequestDTO;
 import io.hhplus.tdd.point.service.UserPointService;
 import io.hhplus.tdd.point.service.UserService;
-import org.apache.coyote.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -28,7 +27,7 @@ public class PointController {
     @GetMapping("{id}")
     public UserPoint point(
             @PathVariable long id
-    ) throws BadRequestException {
+    ) {
         //포인트 조회
         UserPoint userPoint = userPointService.getPointAmount(id);
 
@@ -51,7 +50,7 @@ public class PointController {
     public UserPoint charge(
             @PathVariable long id,
             @RequestBody UserPointRequestDTO requestDTO
-            ) throws BadRequestException{
+            ) {
         return userPointService.chargeUserPoint(id, requestDTO.getAmount());
     }
 
@@ -60,7 +59,7 @@ public class PointController {
     public UserPoint use(
             @PathVariable long id,
             @RequestBody UserPointRequestDTO requestDTO
-    ) throws BadRequestException {
+    ) {
         return userPointService.useUserPoint(id, requestDTO.getAmount());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -1,5 +1,9 @@
 package io.hhplus.tdd.point;
 
+import io.hhplus.tdd.point.dto.UserPointRequestDTO;
+import io.hhplus.tdd.point.service.UserPointService;
+import io.hhplus.tdd.point.service.UserService;
+import org.apache.coyote.BadRequestException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -10,6 +14,14 @@ import java.util.List;
 @RequestMapping("/point")
 public class PointController {
 
+    UserService userService;
+    UserPointService userPointService;
+
+    public PointController(UserService userService, UserPointService userPointService) {
+        this.userService = userService;
+        this.userPointService = userPointService;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
 
     /**
@@ -18,8 +30,11 @@ public class PointController {
     @GetMapping("{id}")
     public UserPoint point(
             @PathVariable long id
-    ) {
-        return new UserPoint(0, 0, 0);
+    ) throws BadRequestException {
+        //포인트 조회
+        UserPoint userPoint = userPointService.getPointAmount(id);
+
+        return userPoint;
     }
 
     /**
@@ -29,7 +44,10 @@ public class PointController {
     public List<PointHistory> history(
             @PathVariable long id
     ) {
-        return List.of();
+        //포인트 내역 조회
+        List<PointHistory> list = userPointService.getPointHistoryByUserId(id);
+
+        return list;
     }
 
     /**
@@ -38,9 +56,9 @@ public class PointController {
     @PatchMapping("{id}/charge")
     public UserPoint charge(
             @PathVariable long id,
-            @RequestBody long amount
-    ) {
-        return new UserPoint(0, 0, 0);
+            @RequestBody UserPointRequestDTO requestDTO
+            ) throws BadRequestException{
+        return userPointService.chargeUserPoint(id, requestDTO.getAmount());
     }
 
     /**
@@ -49,8 +67,8 @@ public class PointController {
     @PatchMapping("{id}/use")
     public UserPoint use(
             @PathVariable long id,
-            @RequestBody long amount
-    ) {
-        return new UserPoint(0, 0, 0);
+            @RequestBody UserPointRequestDTO requestDTO
+    ) throws BadRequestException {
+        return userPointService.useUserPoint(id, requestDTO.getAmount());
     }
 }

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -2,7 +2,6 @@ package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.point.dto.UserPointRequestDTO;
 import io.hhplus.tdd.point.service.UserPointService;
-import io.hhplus.tdd.point.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -13,11 +12,9 @@ import java.util.List;
 @RequestMapping("/point")
 public class PointController {
 
-    UserService userService;
     UserPointService userPointService;
 
-    public PointController(UserService userService, UserPointService userPointService) {
-        this.userService = userService;
+    public PointController(UserPointService userPointService) {
         this.userPointService = userPointService;
     }
 

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -2,6 +2,7 @@ package io.hhplus.tdd.point;
 
 import io.hhplus.tdd.point.dto.UserPointRequestDTO;
 import io.hhplus.tdd.point.service.UserPointService;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.*;
@@ -10,13 +11,10 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/point")
+@RequiredArgsConstructor
 public class PointController {
 
-    UserPointService userPointService;
-
-    public PointController(UserPointService userPointService) {
-        this.userPointService = userPointService;
-    }
+    private final UserPointService userPointService;
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
 

--- a/src/main/java/io/hhplus/tdd/point/PointController.java
+++ b/src/main/java/io/hhplus/tdd/point/PointController.java
@@ -24,9 +24,7 @@ public class PointController {
 
     private static final Logger log = LoggerFactory.getLogger(PointController.class);
 
-    /**
-     * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
-     */
+    /* 특정 유저의 포인트를 조회하는 기능 */
     @GetMapping("{id}")
     public UserPoint point(
             @PathVariable long id
@@ -37,9 +35,7 @@ public class PointController {
         return userPoint;
     }
 
-    /**
-     * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
-     */
+    /* 특정 유저의 포인트 충전/이용 내역을 조회하는 기능 */
     @GetMapping("{id}/histories")
     public List<PointHistory> history(
             @PathVariable long id
@@ -50,9 +46,7 @@ public class PointController {
         return list;
     }
 
-    /**
-     * TODO - 특정 유저의 포인트를 충전하는 기능을 작성해주세요.
-     */
+    /* 특정 유저의 포인트를 충전하는 기능 */
     @PatchMapping("{id}/charge")
     public UserPoint charge(
             @PathVariable long id,
@@ -61,9 +55,7 @@ public class PointController {
         return userPointService.chargeUserPoint(id, requestDTO.getAmount());
     }
 
-    /**
-     * TODO - 특정 유저의 포인트를 사용하는 기능을 작성해주세요.
-     */
+    /* 특정 유저의 포인트를 사용하는 기능 */
     @PatchMapping("{id}/use")
     public UserPoint use(
             @PathVariable long id,

--- a/src/main/java/io/hhplus/tdd/point/dto/UserPointRequestDTO.java
+++ b/src/main/java/io/hhplus/tdd/point/dto/UserPointRequestDTO.java
@@ -1,0 +1,8 @@
+package io.hhplus.tdd.point.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserPointRequestDTO {
+    long amount;
+}

--- a/src/main/java/io/hhplus/tdd/point/lock/UserPointLockManager.java
+++ b/src/main/java/io/hhplus/tdd/point/lock/UserPointLockManager.java
@@ -1,0 +1,35 @@
+package io.hhplus.tdd.point.lock;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class UserPointLockManager {
+    private static final Map<Long, Lock> userPointLocks = new ConcurrentHashMap<>();
+
+    private static Lock getLock(long userId) {
+        return userPointLocks.computeIfAbsent(userId, k -> new ReentrantLock());
+    }
+
+    public static void lock(long userId) {
+        Lock lock = getLock(userId);
+
+        lock.lock();
+    }
+
+    public static void unlock(long userId) {
+        Lock lock = getLock(userId);
+
+        if(ObjectUtils.isEmpty(lock)) {
+            throw new RuntimeException("존재하지 않는 Lock 객체 입니다.");
+        }
+
+        lock.unlock();
+        //userPointLocks.remove(userId); //TODO remove 안 하면 Map에 계속 데이터가 쌓일텐데 이 부분에 대한 처리는 어떻게 할 지에 대해 생각하기
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/lock/UserPointLockManager.java
+++ b/src/main/java/io/hhplus/tdd/point/lock/UserPointLockManager.java
@@ -13,7 +13,7 @@ public class UserPointLockManager {
     private static final Map<Long, Lock> userPointLocks = new ConcurrentHashMap<>();
 
     private static Lock getLock(long userId) {
-        return userPointLocks.computeIfAbsent(userId, k -> new ReentrantLock());
+        return userPointLocks.computeIfAbsent(userId, k -> new ReentrantLock(true));
     }
 
     public static void lock(long userId) {

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
@@ -1,0 +1,42 @@
+package io.hhplus.tdd.point.repository;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.TransactionType;
+import io.hhplus.tdd.point.UserPoint;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class UserPointRepository {
+    UserPointTable userPointTable;
+    PointHistoryTable pointHistoryTable;
+
+    public UserPointRepository(UserPointTable userPointTable, PointHistoryTable pointHistoryTable) {
+        this.userPointTable = userPointTable;
+        this.pointHistoryTable = pointHistoryTable;
+    }
+
+
+    public UserPoint selectById(long id) {
+        return userPointTable.selectById(id);
+    }
+
+    public List<PointHistory> selectAllByUserId(long id) {
+        return pointHistoryTable.selectAllByUserId(id);
+    }
+
+    public UserPoint updateUserPoint(long id, long amount) {
+        return userPointTable.insertOrUpdate(id, amount);
+    }
+
+    public PointHistory insertPointHistoryofCharge(long id, long amount) {
+        return pointHistoryTable.insert(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
+    }
+
+    public PointHistory insertPointHistoryofUse(long id, long amount) {
+        return pointHistoryTable.insert(id, amount, TransactionType.USE, System.currentTimeMillis());
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
+++ b/src/main/java/io/hhplus/tdd/point/repository/UserPointRepository.java
@@ -5,20 +5,16 @@ import io.hhplus.tdd.database.UserPointTable;
 import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.TransactionType;
 import io.hhplus.tdd.point.UserPoint;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
+@RequiredArgsConstructor
 public class UserPointRepository {
-    UserPointTable userPointTable;
-    PointHistoryTable pointHistoryTable;
-
-    public UserPointRepository(UserPointTable userPointTable, PointHistoryTable pointHistoryTable) {
-        this.userPointTable = userPointTable;
-        this.pointHistoryTable = pointHistoryTable;
-    }
-
+    private final UserPointTable userPointTable;
+    private final PointHistoryTable pointHistoryTable;
 
     public UserPoint selectById(long id) {
         return userPointTable.selectById(id);

--- a/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
@@ -1,0 +1,62 @@
+package io.hhplus.tdd.point.service;
+
+import io.hhplus.tdd.point.PointHistory;
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.repository.UserPointRepository;
+import org.apache.coyote.BadRequestException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class UserPointService {
+    UserPointRepository userPointRepository;
+
+    long maximumPoint = 10000000;
+
+    public UserPointService(UserPointRepository userPointRepository) {
+        this.userPointRepository = userPointRepository;
+    }
+
+    public UserPoint getPointAmount(long id) {
+        return userPointRepository.selectById(id);
+    }
+
+    //유저가 가진 전체 포인트 내역을 조회한다.
+    public List<PointHistory> getPointHistoryByUserId(long id) {
+        return userPointRepository.selectAllByUserId(id);
+    }
+
+    public UserPoint chargeUserPoint(long id, long amount) throws BadRequestException{
+        if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
+            throw new BadRequestException("적립할 포인트 금액이 유효하지 않습니다.");
+        }
+
+        UserPoint savedUserPoint = getPointAmount(id);
+        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, savedUserPoint.point() + amount); //tood 조회 포인트 객체와 인서트 포인트 객체 따로 두는게 나을듯
+
+        userPointRepository.insertPointHistoryofCharge(id, amount);
+
+        if(updatedUserPoint.point() > maximumPoint) {
+           throw new BadRequestException("최대 보유 가능한 포인트 잔액을 초과합니다.");
+        }
+        return updatedUserPoint;
+    }
+
+    public UserPoint useUserPoint(long id, long amount) throws BadRequestException{
+        if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
+            throw new BadRequestException("사용할 포인트 금액이 유효하지 않습니다.");
+        }
+
+        UserPoint savedUserPoint = getPointAmount(id);
+        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, savedUserPoint.point() - amount); //tood 조회 포인트 객체와 인서트 포인트 객체 따로 두는게 나을듯
+
+        userPointRepository.insertPointHistoryofUse(id, amount);
+
+        if(updatedUserPoint.point() < 0) {
+            throw new BadRequestException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+        }
+
+        return updatedUserPoint;
+    }
+}

--- a/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
@@ -3,7 +3,6 @@ package io.hhplus.tdd.point.service;
 import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.UserPoint;
 import io.hhplus.tdd.point.repository.UserPointRepository;
-import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,7 +11,7 @@ import java.util.List;
 public class UserPointService {
     UserPointRepository userPointRepository;
 
-    long maximumPoint = 10000000;
+    long maximumPoint = 10_000_000;
 
     public UserPointService(UserPointRepository userPointRepository) {
         this.userPointRepository = userPointRepository;
@@ -27,9 +26,9 @@ public class UserPointService {
         return userPointRepository.selectAllByUserId(id);
     }
 
-    public UserPoint chargeUserPoint(long id, long amount) throws BadRequestException{
+    public UserPoint chargeUserPoint(long id, long amount) {
         if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
-            throw new BadRequestException("적립할 포인트 금액이 유효하지 않습니다.");
+            throw new IllegalArgumentException("적립할 포인트 금액이 유효하지 않습니다.");
         }
 
         UserPoint savedUserPoint = getPointAmount(id);
@@ -38,14 +37,14 @@ public class UserPointService {
         userPointRepository.insertPointHistoryofCharge(id, amount);
 
         if(updatedUserPoint.point() > maximumPoint) {
-           throw new BadRequestException("최대 보유 가능한 포인트 잔액을 초과합니다.");
+           throw new IllegalArgumentException("최대 보유 가능한 포인트 잔액을 초과합니다.");
         }
         return updatedUserPoint;
     }
 
-    public UserPoint useUserPoint(long id, long amount) throws BadRequestException{
+    public UserPoint useUserPoint(long id, long amount) throws IllegalArgumentException{
         if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
-            throw new BadRequestException("사용할 포인트 금액이 유효하지 않습니다.");
+            throw new IllegalArgumentException("사용할 포인트 금액이 유효하지 않습니다.");
         }
 
         UserPoint savedUserPoint = getPointAmount(id);
@@ -54,7 +53,7 @@ public class UserPointService {
         userPointRepository.insertPointHistoryofUse(id, amount);
 
         if(updatedUserPoint.point() < 0) {
-            throw new BadRequestException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+            throw new IllegalArgumentException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
         }
 
         return updatedUserPoint;

--- a/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
@@ -3,19 +3,17 @@ package io.hhplus.tdd.point.service;
 import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.UserPoint;
 import io.hhplus.tdd.point.repository.UserPointRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class UserPointService {
-    UserPointRepository userPointRepository;
+    private final UserPointRepository userPointRepository;
 
-    long maximumPoint = 10_000_000;
-
-    public UserPointService(UserPointRepository userPointRepository) {
-        this.userPointRepository = userPointRepository;
-    }
+    private final long MAXIMUM_POINT = 10_000_000;
 
     public UserPoint getPointAmount(long id) {
         return userPointRepository.selectById(id);
@@ -26,35 +24,40 @@ public class UserPointService {
         return userPointRepository.selectAllByUserId(id);
     }
 
-    public UserPoint chargeUserPoint(long id, long amount) {
-        if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
+    public UserPoint chargeUserPoint(long id, long amount) throws IllegalArgumentException {
+        if(amount < 0 || amount > MAXIMUM_POINT) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
             throw new IllegalArgumentException("적립할 포인트 금액이 유효하지 않습니다.");
         }
 
         UserPoint savedUserPoint = getPointAmount(id);
-        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, savedUserPoint.point() + amount); //tood 조회 포인트 객체와 인서트 포인트 객체 따로 두는게 나을듯
+
+        long willUpdatePointAmount = savedUserPoint.point() + amount;
+        if (willUpdatePointAmount > MAXIMUM_POINT) {
+            throw new IllegalArgumentException("최대 보유 가능한 포인트 잔액을 초과합니다.");
+        }
+
+        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
 
         userPointRepository.insertPointHistoryofCharge(id, amount);
 
-        if(updatedUserPoint.point() > maximumPoint) {
-           throw new IllegalArgumentException("최대 보유 가능한 포인트 잔액을 초과합니다.");
-        }
         return updatedUserPoint;
     }
 
     public UserPoint useUserPoint(long id, long amount) throws IllegalArgumentException{
-        if(amount < 0 || amount > maximumPoint) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
+        if(amount < 0 || amount > MAXIMUM_POINT) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
             throw new IllegalArgumentException("사용할 포인트 금액이 유효하지 않습니다.");
         }
 
         UserPoint savedUserPoint = getPointAmount(id);
-        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, savedUserPoint.point() - amount); //tood 조회 포인트 객체와 인서트 포인트 객체 따로 두는게 나을듯
 
-        userPointRepository.insertPointHistoryofUse(id, amount);
-
-        if(updatedUserPoint.point() < 0) {
+        long willUpdatePointAmount = savedUserPoint.point() - amount;
+        if (willUpdatePointAmount < 0) {
             throw new IllegalArgumentException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
         }
+
+        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
+
+        userPointRepository.insertPointHistoryofUse(id, amount);
 
         return updatedUserPoint;
     }

--- a/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/UserPointService.java
@@ -2,6 +2,7 @@ package io.hhplus.tdd.point.service;
 
 import io.hhplus.tdd.point.PointHistory;
 import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.lock.UserPointLockManager;
 import io.hhplus.tdd.point.repository.UserPointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,19 +29,25 @@ public class UserPointService {
         if(amount < 0 || amount > MAXIMUM_POINT) { //todo(나경) 이거는 객체의 책임으로 가져갈수 있을 것 같음. 더 고민해 보기
             throw new IllegalArgumentException("적립할 포인트 금액이 유효하지 않습니다.");
         }
+        UserPointLockManager.lock(id);
 
-        UserPoint savedUserPoint = getPointAmount(id);
+        try {
+            UserPoint savedUserPoint = getPointAmount(id);
 
-        long willUpdatePointAmount = savedUserPoint.point() + amount;
-        if (willUpdatePointAmount > MAXIMUM_POINT) {
-            throw new IllegalArgumentException("최대 보유 가능한 포인트 잔액을 초과합니다.");
+            long willUpdatePointAmount = savedUserPoint.point() + amount;
+            if (willUpdatePointAmount > MAXIMUM_POINT) {
+                throw new IllegalArgumentException("최대 보유 가능한 포인트 잔액을 초과합니다.");
+            }
+
+            UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
+
+            userPointRepository.insertPointHistoryofCharge(id, amount);
+
+            return updatedUserPoint;
+
+        } finally {
+            UserPointLockManager.unlock(id);
         }
-
-        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
-
-        userPointRepository.insertPointHistoryofCharge(id, amount);
-
-        return updatedUserPoint;
     }
 
     public UserPoint useUserPoint(long id, long amount) throws IllegalArgumentException{
@@ -48,17 +55,24 @@ public class UserPointService {
             throw new IllegalArgumentException("사용할 포인트 금액이 유효하지 않습니다.");
         }
 
-        UserPoint savedUserPoint = getPointAmount(id);
+        UserPointLockManager.lock(id);
 
-        long willUpdatePointAmount = savedUserPoint.point() - amount;
-        if (willUpdatePointAmount < 0) {
-            throw new IllegalArgumentException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+        try {
+            UserPoint savedUserPoint = getPointAmount(id);
+
+            long willUpdatePointAmount = savedUserPoint.point() - amount;
+            if (willUpdatePointAmount < 0) {
+                throw new IllegalArgumentException("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+            }
+
+            UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
+
+            userPointRepository.insertPointHistoryofUse(id, amount);
+
+            return updatedUserPoint;
+
+        } finally {
+            UserPointLockManager.unlock(id);
         }
-
-        UserPoint updatedUserPoint = userPointRepository.updateUserPoint(id, willUpdatePointAmount);
-
-        userPointRepository.insertPointHistoryofUse(id, amount);
-
-        return updatedUserPoint;
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
@@ -9,8 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -34,17 +33,13 @@ class UserPointServiceTest {
         given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 500, System.currentTimeMillis()));
 
         //when
-        try {
-            UserPoint userPoint = userPointService.chargeUserPoint(id, amount);
+        UserPoint userPoint = userPointService.chargeUserPoint(id, amount);
 
-            //then
-            assertThat(userPoint.point()).isEqualTo(500);
+        //then
+        assertThat(userPoint.point()).isEqualTo(500);
 
-            verify(userPointRepository).updateUserPoint(eq(id), eq(amount));
-            verify(userPointRepository).insertPointHistoryofCharge(eq(id), eq(amount));
-        }catch(Exception e) {
-            fail();
-        }
+        verify(userPointRepository).updateUserPoint(eq(id), eq(amount));
+        verify(userPointRepository).insertPointHistoryofCharge(eq(id), eq(amount));
     }
 
     @Test
@@ -53,13 +48,10 @@ class UserPointServiceTest {
         long id = 0L;
         long amount = -500;
 
-        //when
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-                    userPointService.chargeUserPoint(id, amount);
-                });
-
-        //then
-        assertThat(exception.getMessage()).isEqualTo("적립할 포인트 금액이 유효하지 않습니다.");
+        //when + then
+        assertThatThrownBy(()->userPointService.chargeUserPoint(id, amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("적립할 포인트 금액이 유효하지 않습니다.");
     }
 
     @Test
@@ -71,16 +63,11 @@ class UserPointServiceTest {
         UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
 
         given(userPointRepository.selectById(anyLong())).willReturn(givenUserPoint);
-        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 10_001_000, System.currentTimeMillis()));
 
-
-        //when
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            userPointService.chargeUserPoint(id, amount);
-        });
-
-        //then
-        assertThat(exception.getMessage()).isEqualTo("최대 보유 가능한 포인트 잔액을 초과합니다.");
+        //when + then
+        assertThatThrownBy(()->userPointService.chargeUserPoint(id, amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최대 보유 가능한 포인트 잔액을 초과합니다.");
     }
 
     @Test
@@ -112,13 +99,10 @@ class UserPointServiceTest {
 
         UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
 
-        //when
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            userPointService.useUserPoint(id, amount);
-        });
-
-        //then
-        assertThat(exception.getMessage()).isEqualTo("사용할 포인트 금액이 유효하지 않습니다.");
+        //when + then
+        assertThatThrownBy(()->userPointService.useUserPoint(id, amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("사용할 포인트 금액이 유효하지 않습니다.");
     }
 
     @Test
@@ -128,14 +112,10 @@ class UserPointServiceTest {
         long amount = 100;
 
         given(userPointRepository.selectById(anyLong())).willReturn(UserPoint.empty(id));
-        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, -100, System.currentTimeMillis()));
 
-        //when
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
-            userPointService.useUserPoint(id, amount);
-        });
-
-        //then
-        assertThat(exception.getMessage()).isEqualTo("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+        //when + then
+        assertThatThrownBy(()->userPointService.useUserPoint(id, amount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
     }
 }

--- a/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
@@ -1,0 +1,149 @@
+package io.hhplus.tdd.point.service;
+
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.repository.UserPointRepository;
+import org.apache.coyote.BadRequestException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserPointServiceTest {
+
+    @InjectMocks
+    UserPointService userPointService;
+
+    @Mock
+    UserPointRepository userPointRepository;
+
+    @Test
+    public void 포인트_충전을_성공한다() {
+        //given
+        long id = 0L;
+        long amount = 500;
+        given(userPointRepository.selectById(anyLong())).willReturn(UserPoint.empty(id));
+        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 500, System.currentTimeMillis()));
+        given(userPointRepository.insertPointHistoryofCharge(anyLong(), anyLong())).willReturn(null);
+
+        //when
+        try {
+            UserPoint userPoint = userPointService.chargeUserPoint(id, amount);
+
+            //then
+            assertThat(userPoint.point()).isEqualTo(500);
+
+            verify(userPointRepository).updateUserPoint(eq(id), eq(amount));
+            verify(userPointRepository).insertPointHistoryofCharge(eq(id), eq(amount));
+        }catch(Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void 포인트가_음수로_입력된다면_포인트_충전을_실패한다() {
+        //given
+        long id = 0L;
+        long amount = -500;
+
+        //when
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+                    userPointService.chargeUserPoint(id, amount);
+                });
+
+        //then
+        assertThat(exception.getMessage()).isEqualTo("적립할 포인트 금액이 유효하지 않습니다.");
+    }
+
+    @Test
+    public void 충전_후_포인트_잔액이_최대_보유_가능한_잔액을_넘는다면_실패한다() {
+        //given
+        long id = 0L;
+        long amount = 10_000_000;
+
+        UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
+
+        given(userPointRepository.selectById(anyLong())).willReturn(givenUserPoint);
+        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 10_001_000, System.currentTimeMillis()));
+
+
+        //when
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            userPointService.chargeUserPoint(id, amount);
+        });
+
+        //then
+        assertThat(exception.getMessage()).isEqualTo("최대 보유 가능한 포인트 잔액을 초과합니다.");
+    }
+
+    @Test
+    public void 포인트_사용에_성공한다() {
+        //given
+        long id = 0L;
+        long amount = 1000;
+
+        UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
+
+        given(userPointRepository.selectById(anyLong())).willReturn(givenUserPoint);
+        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 0, System.currentTimeMillis()));
+        given(userPointRepository.insertPointHistoryofUse(anyLong(), anyLong())).willReturn(null);
+
+
+        //when
+        try {
+            UserPoint userPoint = userPointService.useUserPoint(id, amount);
+
+            //then
+            assertThat(userPoint.point()).isEqualTo(0);
+
+            verify(userPointRepository).updateUserPoint(eq(id), eq(0L));
+            verify(userPointRepository).insertPointHistoryofUse(eq(id), eq(amount));
+        } catch(Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void 포인트가_음수로_입력된다면_포인트_사용에_실패한다() {
+        //given
+        long id = 0L;
+        long amount = -100;
+
+        UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
+
+        //when
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            userPointService.useUserPoint(id, amount);
+        });
+
+        //then
+        assertThat(exception.getMessage()).isEqualTo("사용할 포인트 금액이 유효하지 않습니다.");
+    }
+
+    @Test
+    public void 사용_후_포인트_잔액이_0_미만일_경우_실패한다() {
+        //given
+        long id = 0L;
+        long amount = 100;
+
+        given(userPointRepository.selectById(anyLong())).willReturn(UserPoint.empty(id));
+        given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, -100, System.currentTimeMillis()));
+
+        //when
+        Exception exception = assertThrows(BadRequestException.class, () -> {
+            userPointService.useUserPoint(id, amount);
+        });
+
+        //then
+        assertThat(exception.getMessage()).isEqualTo("보유한 포인트 금액을 초과하여 사용할 수 없습니다.");
+    }
+}

--- a/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/UserPointServcieTest.java
@@ -2,7 +2,6 @@ package io.hhplus.tdd.point.service;
 
 import io.hhplus.tdd.point.UserPoint;
 import io.hhplus.tdd.point.repository.UserPointRepository;
-import org.apache.coyote.BadRequestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -33,7 +32,6 @@ class UserPointServiceTest {
         long amount = 500;
         given(userPointRepository.selectById(anyLong())).willReturn(UserPoint.empty(id));
         given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 500, System.currentTimeMillis()));
-        given(userPointRepository.insertPointHistoryofCharge(anyLong(), anyLong())).willReturn(null);
 
         //when
         try {
@@ -56,7 +54,7 @@ class UserPointServiceTest {
         long amount = -500;
 
         //when
-        Exception exception = assertThrows(BadRequestException.class, () -> {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
                     userPointService.chargeUserPoint(id, amount);
                 });
 
@@ -77,7 +75,7 @@ class UserPointServiceTest {
 
 
         //when
-        Exception exception = assertThrows(BadRequestException.class, () -> {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             userPointService.chargeUserPoint(id, amount);
         });
 
@@ -95,21 +93,15 @@ class UserPointServiceTest {
 
         given(userPointRepository.selectById(anyLong())).willReturn(givenUserPoint);
         given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, 0, System.currentTimeMillis()));
-        given(userPointRepository.insertPointHistoryofUse(anyLong(), anyLong())).willReturn(null);
-
 
         //when
-        try {
-            UserPoint userPoint = userPointService.useUserPoint(id, amount);
+        UserPoint userPoint = userPointService.useUserPoint(id, amount);
 
-            //then
-            assertThat(userPoint.point()).isEqualTo(0);
+        //then
+        assertThat(userPoint.point()).isEqualTo(0);
 
-            verify(userPointRepository).updateUserPoint(eq(id), eq(0L));
-            verify(userPointRepository).insertPointHistoryofUse(eq(id), eq(amount));
-        } catch(Exception e) {
-            fail();
-        }
+        verify(userPointRepository).updateUserPoint(eq(id), eq(0L));
+        verify(userPointRepository).insertPointHistoryofUse(eq(id), eq(amount));
     }
 
     @Test
@@ -121,7 +113,7 @@ class UserPointServiceTest {
         UserPoint givenUserPoint = new UserPoint(id, 1000, System.currentTimeMillis());
 
         //when
-        Exception exception = assertThrows(BadRequestException.class, () -> {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             userPointService.useUserPoint(id, amount);
         });
 
@@ -139,7 +131,7 @@ class UserPointServiceTest {
         given(userPointRepository.updateUserPoint(anyLong(), anyLong())).willReturn(new UserPoint(id, -100, System.currentTimeMillis()));
 
         //when
-        Exception exception = assertThrows(BadRequestException.class, () -> {
+        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
             userPointService.useUserPoint(id, amount);
         });
 

--- a/src/test/java/io/hhplus/tdd/point/service/UserPointServiceConcurrencyTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/UserPointServiceConcurrencyTest.java
@@ -1,0 +1,149 @@
+package io.hhplus.tdd.point.service;
+
+import io.hhplus.tdd.database.PointHistoryTable;
+import io.hhplus.tdd.database.UserPointTable;
+import io.hhplus.tdd.point.UserPoint;
+import io.hhplus.tdd.point.repository.UserPointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class UserPointServiceConcurrencyTest {
+
+    UserPointService userPointService;
+
+    @BeforeEach
+    public void setup() {
+        UserPointTable userPointTable = new UserPointTable();
+        PointHistoryTable pointHistoryTable = new PointHistoryTable();
+
+        UserPointRepository userPointRepository = new UserPointRepository(userPointTable, pointHistoryTable);
+        userPointService = new UserPointService(userPointRepository);
+    }
+
+    @Test
+    public void 동시에_여러_스레드가_포인트를_충전해도_최종_포인트_값이_일치해야_한다() throws InterruptedException {
+        //given
+        long id = 1L;
+        long chargeAmount = 100L;
+
+        int threadCount = 10;
+
+        //when
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        //여러 스레드에서 충전 작업 실행
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    userPointService.chargeUserPoint(id, chargeAmount);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 작업 완료 대기
+        latch.await();
+        executorService.shutdown();
+
+        //then
+        long expectedPoint = chargeAmount * threadCount;
+        UserPoint userPoint = userPointService.getPointAmount(id);
+
+        assertThat(userPoint.point()).isEqualTo(expectedPoint);
+    }
+
+    @Test
+    public void 동시에_여러_스레드가_포인트를_사용해도_최종_포인트_값이_일치해야_한다() throws InterruptedException {
+        //given
+        long id = 1L;
+        long useAmount = 100L;
+        long initialPoint = 1000L;
+
+        int threadCount = 10;
+
+        userPointService.chargeUserPoint(id, initialPoint);
+
+        //when
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        //여러 스레드에서 충전 작업 실행
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    userPointService.useUserPoint(id, useAmount);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 작업 완료 대기
+        latch.await();
+        executorService.shutdown();
+
+        //then
+        long expectedPoint = 0;
+        UserPoint userPoint = userPointService.getPointAmount(id);
+
+        assertThat(userPoint.point()).isEqualTo(expectedPoint);
+    }
+
+    @Test
+    public void 동시에_여러_스레드가_포인트를_충전하고_사용해도_최종_포인트_값이_일치해야_한다() throws InterruptedException {
+        //given
+        long id = 1L;
+        long amount = 100L;
+
+        int threadCount = 10;
+
+
+        //when
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        //여러 스레드에서 충전 작업 실행
+        for (int i = 0; i < threadCount; i++) {
+            executorService.execute(() -> {
+                try {
+                    userPointService.chargeUserPoint(id, amount);
+
+                    userPointService.useUserPoint(id, amount);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        // 모든 작업 완료 대기
+        latch.await();
+        executorService.shutdown();
+
+        //then
+        long expectedPoint = 0;
+        UserPoint userPoint = userPointService.getPointAmount(id);
+
+        assertThat(userPoint.point()).isEqualTo(expectedPoint);
+    }
+}
+


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

- feat: 포인트 조회 / 내역 조회 / 충전 / 사용 기능 추가 및 테스트 코드 작성 : 37f6eed
- refactor: BadRequestException을 IllegalArgumentException으로 수정: 945cc12
- refactor: @requiredargsconstructor 추가 및 테스트 코드 개선: 2722fbc
- feat: 동시성 처리 및 테스트 코드 작성 : fe30733

---
### **리뷰 포인트(질문)**
- 'UserPointService' 컴포넌트에서 포인트 금액에 대한 유효성 체크를 하면서 Exception을 내보내고 있습니다. 처음에는 'BadRequestException'을 사용하다가'IllegalArgumentException'으로 변경하였는데, 이런 경우 어떤 Exception을 내보내는 것이 적합한지 궁금합니다.

- 앞과 비슷한 내용으로 'UserPointLockManager'에서 에러가 발생하면 'RuntimeException'을 내보내고 있는데 더 적합한 Exception이 있는지, 실무에서는 처리를 어떻게 하는지 궁금합니다.

- 'UserPointLockManager' 에서 'userPointLocks'와 메서드를 static으로 선언하고 있는데 이렇게 구현하는게 맞는지 더 나은 방법이 있는지 확인 부탁 드립니다.

- 'UserPointLockManager' 컴포넌트에서 ConcurrentHashMap을 이용해 userId에 대해 락 객체를 만들고 있습니다. 만약 10만명의 유저가 있어서 락을 할경우 Map에 데이터가 끊임없이 쌓일 것 같은데, 이런 경우 ConcurrentHashMap 안에 쌓인 데이터 관리는 어떻게 하는지 궁금합니다. 

- 'UserPointServiceConcurrencyTest' 테스트 코드 중 충전과 사용을 동시에 하는 테스트 코드가 있는데 아래의 코드 처럼 하나의 쓰레드에 충전과 사용을 동시에 넣어서 테스트를 진행했는지 이렇게 진행하는 게 맞는지 확인 부탁드립니다.
```
 for (int i = 0; i < threadCount; i++) {
            executorService.execute(() -> {
                try {
                    userPointService.chargeUserPoint(id, amount);

                    userPointService.useUserPoint(id, amount);
                } finally {
                    latch.countDown();
                }
            });
        }

```
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->
- Lock에 대한 내용을 UserPointLockManager 클래스로 따로 빼서 관리함.

### Problem
<!--개선이 필요한 점-->
- ConcurrentHashMap에서 lock 객체를 관리하고 있는데 ConcurrentHashMap에 대한 데이터 관리 개선
   - 현재 map에 계속 쌓이는 코드만 있는데, 계속 쌓이면 메모리 낭비가 심할 것 같아서 이 부분에 대한 개선이 필요할 것 같음
- Point 값에 대하여 음수인지 최대값을 넘는 지 확인하는 부분이 중복되고 있음. 이 부분에 대한 유효성 검사는 객체의 책임으로 넘기면 좋을 것 같다.

### Try
<!-- 새롭게 시도할 점 -->
- Repository에 대한 테스트 코드 작성
- 예측 가능한 Exception에 대해 커스텀화하기
